### PR TITLE
Add missing dependency for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "micromark-util-normalize-identifier": "^1.0.0",
     "micromark-util-sanitize-uri": "^1.0.0",
     "micromark-util-symbol": "^1.0.0",
+    "micromark-util-types": "^1.0.0",
     "uvu": "^0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Fix these build errors:

```
ERROR in ../../.yarn/cache/micromark-extension-gfm-footnote-npm-1.0.3-4f3ceb79de-81aaf12d23.zip/node_modules/micromark-extension-gfm-footnote/lib/html.d.ts 6:36-58
TS2307: Cannot find module 'micromark-util-types' or its corresponding type declarations.
    4 |  */
    5 | export function gfmFootnoteHtml(options?: Options | undefined): HtmlExtension
  > 6 | export type HtmlExtension = import('micromark-util-types').HtmlExtension
      |                                    ^^^^^^^^^^^^^^^^^^^^^^
    7 | export type CompileContext = import('micromark-util-types').CompileContext
    8 | export type Options = {
    9 |   /**

ERROR in ../../.yarn/cache/micromark-extension-gfm-footnote-npm-1.0.3-4f3ceb79de-81aaf12d23.zip/node_modules/micromark-extension-gfm-footnote/lib/html.d.ts 7:37-59
TS2307: Cannot find module 'micromark-util-types' or its corresponding type declarations.
     5 | export function gfmFootnoteHtml(options?: Options | undefined): HtmlExtension
     6 | export type HtmlExtension = import('micromark-util-types').HtmlExtension
  >  7 | export type CompileContext = import('micromark-util-types').CompileContext
       |                                     ^^^^^^^^^^^^^^^^^^^^^^
     8 | export type Options = {
     9 |   /**
    10 |    * Prefix to use before the `id` attribute to prevent it from *clobbering*.

ERROR in ../../.yarn/cache/micromark-extension-gfm-footnote-npm-1.0.3-4f3ceb79de-81aaf12d23.zip/node_modules/micromark-extension-gfm-footnote/lib/syntax.d.ts 5:32-54
TS2307: Cannot find module 'micromark-util-types' or its corresponding type declarations.
    3 |  */
    4 | export function gfmFootnote(): Extension
  > 5 | export type Extension = import('micromark-util-types').Extension
      |                                ^^^^^^^^^^^^^^^^^^^^^^
    6 | export type Resolver = import('micromark-util-types').Resolver
    7 | export type Token = import('micromark-util-types').Token
    8 | export type Tokenizer = import('micromark-util-types').Tokenizer

ERROR in ../../.yarn/cache/micromark-extension-gfm-footnote-npm-1.0.3-4f3ceb79de-81aaf12d23.zip/node_modules/micromark-extension-gfm-footnote/lib/syntax.d.ts 6:31-53
TS2307: Cannot find module 'micromark-util-types' or its corresponding type declarations.
    4 | export function gfmFootnote(): Extension
    5 | export type Extension = import('micromark-util-types').Extension
  > 6 | export type Resolver = import('micromark-util-types').Resolver
      |                               ^^^^^^^^^^^^^^^^^^^^^^
    7 | export type Token = import('micromark-util-types').Token
    8 | export type Tokenizer = import('micromark-util-types').Tokenizer
    9 | export type Exiter = import('micromark-util-types').Exiter

ERROR in ../../.yarn/cache/micromark-extension-gfm-footnote-npm-1.0.3-4f3ceb79de-81aaf12d23.zip/node_modules/micromark-extension-gfm-footnote/lib/syntax.d.ts 7:28-50
TS2307: Cannot find module 'micromark-util-types' or its corresponding type declarations.
     5 | export type Extension = import('micromark-util-types').Extension
     6 | export type Resolver = import('micromark-util-types').Resolver
  >  7 | export type Token = import('micromark-util-types').Token
       |                            ^^^^^^^^^^^^^^^^^^^^^^
     8 | export type Tokenizer = import('micromark-util-types').Tokenizer
     9 | export type Exiter = import('micromark-util-types').Exiter
    10 | export type State = import('micromark-util-types').State

ERROR in ../../.yarn/cache/micromark-extension-gfm-footnote-npm-1.0.3-4f3ceb79de-81aaf12d23.zip/node_modules/micromark-extension-gfm-footnote/lib/syntax.d.ts 8:32-54
TS2307: Cannot find module 'micromark-util-types' or its corresponding type declarations.
     6 | export type Resolver = import('micromark-util-types').Resolver
     7 | export type Token = import('micromark-util-types').Token
  >  8 | export type Tokenizer = import('micromark-util-types').Tokenizer
       |                                ^^^^^^^^^^^^^^^^^^^^^^
     9 | export type Exiter = import('micromark-util-types').Exiter
    10 | export type State = import('micromark-util-types').State
    11 | export type Event = import('micromark-util-types').Event

ERROR in ../../.yarn/cache/micromark-extension-gfm-footnote-npm-1.0.3-4f3ceb79de-81aaf12d23.zip/node_modules/micromark-extension-gfm-footnote/lib/syntax.d.ts 9:29-51
TS2307: Cannot find module 'micromark-util-types' or its corresponding type declarations.
     7 | export type Token = import('micromark-util-types').Token
     8 | export type Tokenizer = import('micromark-util-types').Tokenizer
  >  9 | export type Exiter = import('micromark-util-types').Exiter
       |                             ^^^^^^^^^^^^^^^^^^^^^^
    10 | export type State = import('micromark-util-types').State
    11 | export type Event = import('micromark-util-types').Event
    12 |

ERROR in ../../.yarn/cache/micromark-extension-gfm-footnote-npm-1.0.3-4f3ceb79de-81aaf12d23.zip/node_modules/micromark-extension-gfm-footnote/lib/syntax.d.ts 10:28-50
TS2307: Cannot find module 'micromark-util-types' or its corresponding type declarations.
     8 | export type Tokenizer = import('micromark-util-types').Tokenizer
     9 | export type Exiter = import('micromark-util-types').Exiter
  > 10 | export type State = import('micromark-util-types').State
       |                            ^^^^^^^^^^^^^^^^^^^^^^
    11 | export type Event = import('micromark-util-types').Event
    12 |

ERROR in ../../.yarn/cache/micromark-extension-gfm-footnote-npm-1.0.3-4f3ceb79de-81aaf12d23.zip/node_modules/micromark-extension-gfm-footnote/lib/syntax.d.ts 11:28-50
TS2307: Cannot find module 'micromark-util-types' or its corresponding type declarations.
     9 | export type Exiter = import('micromark-util-types').Exiter
    10 | export type State = import('micromark-util-types').State
  > 11 | export type Event = import('micromark-util-types').Event
       |                            ^^^^^^^^^^^^^^^^^^^^^^
    12 |
```
<!--do not edit: pr-->
