### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -413,6 +413,7 @@ For the complete actual CSS see
   font-size: smaller;
   color: #8b949e;
   border-top: 1px solid #30363d;
+  word-wrap: break-word;
 }
 
 /* Hide the section label for visual users. */


### PR DESCRIPTION
Add CSS to prevent text overflow.

Normally, this style should be inherited from ancestor elements(In `github-markdown-css`, this style is set in `.markdown-body`.). However, if no ancestor element has set this style, it's better to set it here.

See: https://github.com/sindresorhus/github-markdown-css/blob/main/github-markdown.css#L106
